### PR TITLE
Add support for open extensions

### DIFF
--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/App_GlobalResources/Resource.designer.cs
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/App_GlobalResources/Resource.designer.cs
@@ -19,7 +19,7 @@ namespace Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option or rebuild the Visual Studio project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Web.Application.StronglyTypedResourceProxyBuilder", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Web.Application.StronglyTypedResourceProxyBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -246,6 +246,78 @@ namespace Resources {
         internal static string Event_UpdateEvent {
             get {
                 return ResourceManager.GetString("Event_UpdateEvent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extensions.
+        /// </summary>
+        internal static string Extensions {
+            get {
+                return ResourceManager.GetString("Extensions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to deleted.
+        /// </summary>
+        internal static string Extensions_deleted {
+            get {
+                return ResourceManager.GetString("Extensions_deleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Extensions.
+        /// </summary>
+        internal static string Extensions_OpenExtensions {
+            get {
+                return ResourceManager.GetString("Extensions_OpenExtensions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add open extension to me.
+        /// </summary>
+        internal static string Extensions_Open_Add {
+            get {
+                return ResourceManager.GetString("Extensions_Open_Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete open extension for me.
+        /// </summary>
+        internal static string Extensions_Open_Delete {
+            get {
+                return ResourceManager.GetString("Extensions_Open_Delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Get open extensions for me.
+        /// </summary>
+        internal static string Extensions_Open_Get {
+            get {
+                return ResourceManager.GetString("Extensions_Open_Get", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update open extension for me.
+        /// </summary>
+        internal static string Extensions_Open_Update {
+            get {
+                return ResourceManager.GetString("Extensions_Open_Update", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to updated.
+        /// </summary>
+        internal static string Extensions_updated {
+            get {
+                return ResourceManager.GetString("Extensions_updated", resourceCulture);
             }
         }
         

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/App_GlobalResources/Resource.resx
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/App_GlobalResources/Resource.resx
@@ -565,4 +565,36 @@
     <value>Upload a large file</value>
     <comment>UploadLargeFile button text for Files view</comment>
   </data>
+  <data name="Extensions" xml:space="preserve">
+    <value>Extensions</value>
+    <comment>Name and partial view title</comment>
+  </data>
+  <data name="Extensions_deleted" xml:space="preserve">
+    <value>deleted</value>
+    <comment>Text for feedback on deletion</comment>
+  </data>
+  <data name="Extensions_OpenExtensions" xml:space="preserve">
+    <value>Open Extensions</value>
+    <comment>Open Extensions title text for Extensions view</comment>
+  </data>
+  <data name="Extensions_Open_Add" xml:space="preserve">
+    <value>Add open extension to me</value>
+    <comment>AddOpenExtensionToMe button text for Extensions view</comment>
+  </data>
+  <data name="Extensions_Open_Delete" xml:space="preserve">
+    <value>Delete open extension for me</value>
+    <comment>DeleteOpenExtensionForMe button text for Extensions view</comment>
+  </data>
+  <data name="Extensions_Open_Get" xml:space="preserve">
+    <value>Get open extensions for me</value>
+    <comment>GetOpenExtensionsForMe button text for Extensions view</comment>
+  </data>
+  <data name="Extensions_Open_Update" xml:space="preserve">
+    <value>Update open extension for me</value>
+    <comment>UpdateOpenExtensionForMe button text for Extensions view</comment>
+  </data>
+  <data name="Extensions_updated" xml:space="preserve">
+    <value>updated</value>
+    <comment>Text for feedback on updating</comment>
+  </data>
 </root>

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Controllers/ExtensionsController.cs
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Controllers/ExtensionsController.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+using Microsoft.Graph;
+using Microsoft_Graph_ASPNET_Snippets.Helpers;
+using Microsoft_Graph_ASPNET_Snippets.Models;
+using Resources;
+
+namespace Microsoft_Graph_ASPNET_Snippets.Controllers
+{
+    [Authorize]
+    public class ExtensionsController : Controller
+    {
+        ExtensionsService extensionsService = new ExtensionsService();
+
+        // Open extensions sample built around https://developer.microsoft.com/en-us/graph/docs/concepts/extensibility_open_users
+        public ActionResult Index()
+        {
+            return View("Extensions");
+        }
+
+        private static readonly string extensionName = "com.contoso.roamingSettings";
+        public async Task<ActionResult> AddOpenExtensionToMe()
+        {
+            ResultsViewModel results = new ResultsViewModel();
+            try
+            {
+                GraphServiceClient graphClient = SDKHelper.GetAuthenticatedClient();
+
+                results.Items = await extensionsService.AddOpenExtensionToMe(graphClient,
+                    extensionName,
+                    new Dictionary<string, object>()
+                            { {"theme", "dark"}, {"color","purple"}, {"lang","Japanese"}});
+            }
+            catch (ServiceException se)
+            {
+                if (se.Error.Message == Resource.Error_AuthChallengeNeeded) return new EmptyResult();
+                return RedirectToAction("Index", "Error", new { message = string.Format(Resource.Error_Message, Request.RawUrl, se.Error.Code, se.Error.Message) });
+            }
+
+            return View("Extensions", results);
+        }
+
+        public async Task<ActionResult> GetOpenExtensionsForMe()
+        {
+            ResultsViewModel results = new ResultsViewModel();
+            try
+            {
+                GraphServiceClient graphClient = SDKHelper.GetAuthenticatedClient();
+
+                results.Items = await extensionsService.GetOpenExtensionsForMe(graphClient);
+            }
+            catch (ServiceException se)
+            {
+                if (se.Error.Message == Resource.Error_AuthChallengeNeeded) return new EmptyResult();
+                return RedirectToAction("Index", "Error", new { message = string.Format(Resource.Error_Message, Request.RawUrl, se.Error.Code, se.Error.Message) });
+            }
+
+            return View("Extensions", results);
+        }
+
+        public async Task<ActionResult> UpdateOpenExtensionForMe()
+        {
+            ResultsViewModel results = new ResultsViewModel();
+            try
+            {
+                GraphServiceClient graphClient = SDKHelper.GetAuthenticatedClient();
+
+                // For updating a single dictionary item, you would first need to retrieve & then update the extension
+                results.Items = await extensionsService.UpdateOpenExtensionForMe(graphClient,
+                    extensionName,
+                    new Dictionary<string, object>()
+                        { {"theme", "light"}, {"color","yellow"}, {"lang","Swahili"}});
+            }
+            catch (ServiceException se)
+            {
+                if (se.Error.Message == Resource.Error_AuthChallengeNeeded) return new EmptyResult();
+                return RedirectToAction("Index", "Error", new { message = string.Format(Resource.Error_Message, Request.RawUrl, se.Error.Code, se.Error.Message) });
+            }
+
+            return View("Extensions", results);
+        }
+
+        public async Task<ActionResult> DeleteOpenExtensionForMe()
+        {
+            ResultsViewModel results = new ResultsViewModel();
+            try
+            {
+                GraphServiceClient graphClient = SDKHelper.GetAuthenticatedClient();
+
+                await extensionsService.DeleteOpenExtensionForMe(graphClient, extensionName);
+
+                results.Items = new List<ResultsItem>() { new ResultsItem() { Display = $"{extensionName} deleted"}};
+            }
+            catch (ServiceException se)
+            {
+                if (se.Error.Message == Resource.Error_AuthChallengeNeeded) return new EmptyResult();
+                return RedirectToAction("Index", "Error", new { message = string.Format(Resource.Error_Message, Request.RawUrl, se.Error.Code, se.Error.Message) });
+            }
+
+            return View("Extensions", results);
+        }
+    }
+}

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Controllers/ExtensionsController.cs
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Controllers/ExtensionsController.cs
@@ -70,10 +70,12 @@ namespace Microsoft_Graph_ASPNET_Snippets.Controllers
                 GraphServiceClient graphClient = SDKHelper.GetAuthenticatedClient();
 
                 // For updating a single dictionary item, you would first need to retrieve & then update the extension
-                results.Items = await extensionsService.UpdateOpenExtensionForMe(graphClient,
+                await extensionsService.UpdateOpenExtensionForMe(graphClient,
                     extensionName,
                     new Dictionary<string, object>()
                         { {"theme", "light"}, {"color","yellow"}, {"lang","Swahili"}});
+
+                results.Items = new List<ResultsItem>() { new ResultsItem() { Display = $"{extensionName} {Resource.Extensions_updated}" } };
             }
             catch (ServiceException se)
             {
@@ -93,7 +95,7 @@ namespace Microsoft_Graph_ASPNET_Snippets.Controllers
 
                 await extensionsService.DeleteOpenExtensionForMe(graphClient, extensionName);
 
-                results.Items = new List<ResultsItem>() { new ResultsItem() { Display = $"{extensionName} deleted"}};
+                results.Items = new List<ResultsItem>() { new ResultsItem() { Display = $"{extensionName} {Resource.Extensions_deleted}" } };
             }
             catch (ServiceException se)
             {

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Microsoft Graph ASPNET Snippets.csproj
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Microsoft Graph ASPNET Snippets.csproj
@@ -26,6 +26,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -180,6 +181,7 @@
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="Controllers\AdminController.cs" />
     <Compile Include="Controllers\EventsController.cs" />
+    <Compile Include="Controllers\ExtensionsController.cs" />
     <Compile Include="Controllers\FilesController.cs" />
     <Compile Include="Controllers\GroupsController.cs" />
     <Compile Include="Controllers\MailController.cs" />
@@ -194,6 +196,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\EventsService.cs" />
+    <Compile Include="Models\ExtensionsService.cs" />
     <Compile Include="Models\FilesService.cs" />
     <Compile Include="Models\GroupsService.cs" />
     <Compile Include="Models\MailService.cs" />
@@ -262,7 +265,9 @@
     <None Include="Properties\PublishProfiles\aspnet-snippets - FTP.pubxml" />
     <None Include="Properties\PublishProfiles\aspnet-snippets - Web Deploy.pubxml" />
     <Content Include="Views\Admin\Admin.cshtml" />
+    <Content Include="Views\Extensions\Extensions.cshtml" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Models/ExtensionsService.cs
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Models/ExtensionsService.cs
@@ -42,7 +42,7 @@ namespace Microsoft_Graph_ASPNET_Snippets.Models
             }).ToList();
         }
 
-        public async Task<List<ResultsItem>> UpdateOpenExtensionForMe(GraphServiceClient graphClient, string extensionName,
+        public async Task UpdateOpenExtensionForMe(GraphServiceClient graphClient, string extensionName,
             Dictionary<string, object> data)
         {
             var openExtension = new OpenTypeExtension
@@ -51,15 +51,9 @@ namespace Microsoft_Graph_ASPNET_Snippets.Models
                 AdditionalData = data
             };
 
-            // BUG: Returns null instead of Extension
+            // Note: Client SDK returns Extension, whereas REST API only return 204 with No content
+            // Thus result is *always* null (Client SDK is generated, some UpdateAsync calls do return results, this doesn't)
             var result = await graphClient.Me.Extensions[extensionName].Request().UpdateAsync(openExtension);
-
-            return new List<ResultsItem>() { new ResultsItem()
-                {
-                    Display = result.Id,
-                    Properties = (Dictionary<string,object>)result.AdditionalData
-                }
-            };
         }
 
         public async Task DeleteOpenExtensionForMe(GraphServiceClient graphClient, string extensionName)

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Models/ExtensionsService.cs
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Models/ExtensionsService.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.Graph;
+using Newtonsoft.Json;
+using Resources;
+using WebGrease.Css.Extensions;
+
+namespace Microsoft_Graph_ASPNET_Snippets.Models
+{
+    public class ExtensionsService
+    {
+        public async Task<List<ResultsItem>> AddOpenExtensionToMe(GraphServiceClient graphClient, string extensionName,
+            Dictionary<string, object> data)
+        {
+            var openExtension = new OpenTypeExtension
+            {
+                ExtensionName = extensionName,
+                AdditionalData = data
+            };
+
+            var result = await graphClient.Me.Extensions.Request().AddAsync(openExtension);
+
+            return new List<ResultsItem>() { new ResultsItem()
+                {
+                    Display = result.Id,
+                    Properties = (Dictionary<string,object>)result.AdditionalData
+                }
+            };
+        }
+
+        public async Task<List<ResultsItem>> GetOpenExtensionsForMe(GraphServiceClient graphClient)
+        {
+            var result = await graphClient.Me.Extensions.Request().GetAsync();
+
+            return result.CurrentPage.Select(r => new ResultsItem()
+            {
+                Display = r.Id,
+                Properties = (Dictionary<string, object>)r.AdditionalData
+            }).ToList();
+        }
+
+        public async Task<List<ResultsItem>> UpdateOpenExtensionForMe(GraphServiceClient graphClient, string extensionName,
+            Dictionary<string, object> data)
+        {
+            var openExtension = new OpenTypeExtension
+            {
+                ExtensionName = extensionName,
+                AdditionalData = data
+            };
+
+            // BUG: Returns null instead of Extension
+            var result = await graphClient.Me.Extensions[extensionName].Request().UpdateAsync(openExtension);
+
+            return new List<ResultsItem>() { new ResultsItem()
+                {
+                    Display = result.Id,
+                    Properties = (Dictionary<string,object>)result.AdditionalData
+                }
+            };
+        }
+
+        public async Task DeleteOpenExtensionForMe(GraphServiceClient graphClient, string extensionName)
+        {
+            await graphClient.Me.Extensions[extensionName].Request().DeleteAsync();
+        }
+    }
+}

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Extensions/Extensions.cshtml
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Extensions/Extensions.cshtml
@@ -1,0 +1,43 @@
+﻿<!--  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
+See LICENSE in the source repository root for complete license information. -->
+
+@using Resources;
+
+@model Microsoft_Graph_ASPNET_Snippets.Models.ResultsViewModel
+
+@{
+    ViewBag.Title = string.Format(Resource.Snippets, "Extensions");
+    var accountType = Session["AccountType"] as string;
+}
+
+<div class="split">
+    <h2>@ViewBag.Title</h2>
+</div>
+<div class="col-sm-12">
+    <h3>Open Extensions</h3>
+    <div class="form-group">
+        @using (Html.BeginForm("AddOpenExtensionToMe", "Extensions"))
+        {
+            <button class="btn btn-link" id="add-openextension">Add open extension to me</button>
+        }
+        @using (Html.BeginForm("GetOpenExtensionsForMe", "Extensions"))
+        {
+            <button class="btn btn-link" id="get-openextensions">Get open extensions for me</button>
+        }
+        @using (Html.BeginForm("UpdateOpenExtensionForMe", "Extensions"))
+        {
+            <button class="btn btn-link" id="update-openextension">Update open extension for me</button>
+        }
+        @using (Html.BeginForm("DeleteOpenExtensionForMe", "Extensions"))
+        {
+            <button class="btn btn-link" id="delete-openextension">Delete open extension for me</button>
+        }
+    </div>
+
+    @*<p>Schema Extensions</p>
+    <div class="form-group">
+    </div>*@
+</div>
+
+
+@Html.Partial("_ResultsPartial")

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Extensions/Extensions.cshtml
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Extensions/Extensions.cshtml
@@ -6,7 +6,7 @@ See LICENSE in the source repository root for complete license information. -->
 @model Microsoft_Graph_ASPNET_Snippets.Models.ResultsViewModel
 
 @{
-    ViewBag.Title = string.Format(Resource.Snippets, "Extensions");
+    ViewBag.Title = string.Format(Resource.Snippets, Resource.Extensions);
     var accountType = Session["AccountType"] as string;
 }
 
@@ -14,23 +14,23 @@ See LICENSE in the source repository root for complete license information. -->
     <h2>@ViewBag.Title</h2>
 </div>
 <div class="col-sm-12">
-    <h3>Open Extensions</h3>
+    <h3>@Resource.Extensions_OpenExtensions</h3>
     <div class="form-group">
         @using (Html.BeginForm("AddOpenExtensionToMe", "Extensions"))
         {
-            <button class="btn btn-link" id="add-openextension">Add open extension to me</button>
+            <button class="btn btn-link" id="add-openextension">@Resource.Extensions_Open_Add</button>
         }
         @using (Html.BeginForm("GetOpenExtensionsForMe", "Extensions"))
         {
-            <button class="btn btn-link" id="get-openextensions">Get open extensions for me</button>
+            <button class="btn btn-link" id="get-openextensions">@Resource.Extensions_Open_Get</button>
         }
         @using (Html.BeginForm("UpdateOpenExtensionForMe", "Extensions"))
         {
-            <button class="btn btn-link" id="update-openextension">Update open extension for me</button>
+            <button class="btn btn-link" id="update-openextension">@Resource.Extensions_Open_Update</button>
         }
         @using (Html.BeginForm("DeleteOpenExtensionForMe", "Extensions"))
         {
-            <button class="btn btn-link" id="delete-openextension">Delete open extension for me</button>
+            <button class="btn btn-link" id="delete-openextension">@Resource.Extensions_Open_Delete</button>
         }
     </div>
 

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Home/Index.cshtml
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Home/Index.cshtml
@@ -2,7 +2,7 @@
         See LICENSE in the source repository root for complete license information. -->
 
 @using Resources;
-		
+
 @{
   ViewBag.Title = Resource.App_Name;
 }
@@ -15,4 +15,5 @@
     @Html.ActionLink("Events", "Index", "Events")<br />
     @Html.ActionLink("Files and folders", "Index", "Files")<br />
     @Html.ActionLink("Groups", "Index", "Groups")<br />
+    @Html.ActionLink("Extensions", "Index", "Extensions")<br />
 </div>

--- a/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Shared/_Layout.cshtml
+++ b/Graph-ASPNET-46-Snippets/Microsoft Graph ASPNET Snippets/Views/Shared/_Layout.cshtml
@@ -39,6 +39,7 @@
                     {
                     <li>@Html.ActionLink("Admin scopes", "Index", "Admin")</li>
                     }
+                    <li>@Html.ActionLink("Extensions", "Index", "Extensions")</li>
                 </ul>
                 @Html.Partial("_LoginPartial")
             </div>


### PR DESCRIPTION
This is a work in progress with request for review.

It implements the open extensions workflow shown in the documentation (https://developer.microsoft.com/en-us/graph/docs/concepts/extensibility_open_users). Notable at this stage:

 * Not using resources (like UserController does)
 * One (possible) bug in the client sdk (see line 55 in ExtensionsService.cs) - I have not tried with the latest Graph client sdk; how should I work around this behavior?
