### PR TITLE
startup.cs: ErrorItemNotFound to ImageNotFound

### DIFF
--- a/SnippetsApp/Startup.cs
+++ b/SnippetsApp/Startup.cs
@@ -87,7 +87,7 @@ namespace SnippetsApp
                         }
                         catch (ServiceException ex)
                         {
-                            if (ex.IsMatch("ErrorItemNotFound"))
+                            if (ex.IsMatch("PitureNotFound"))
                             {
                                 context.Principal.AddUserGraphPhoto(null);
                             }


### PR DESCRIPTION
replacing ErrorItemNotFound with ImageNotFound in startup.cs to avoid the following for new build/run on user that has never had a picture:

![2022-05-06 13_56_23-Home Page - Graph Snippets and 2 more pages - Work 5 - Microsoft​ Edge](https://user-images.githubusercontent.com/102706433/167211219-d75e5be8-dd85-4e85-bcbb-5e5a38a48353.png)

![2022-05-06 13_57_42-Home Page - Graph Snippets and 2 more pages - Work 5 - Microsoft​ Edge](https://user-images.githubusercontent.com/102706433/167211338-a11e2b55-56ad-4417-abfb-335834265c0c.png)

